### PR TITLE
Fixed spreadsheet column ordering

### DIFF
--- a/index.php
+++ b/index.php
@@ -203,7 +203,7 @@ function copyToClipboard(text) {
 	</div>
 	<div class="clearfix"></div>
 <div id="AccountInfo">
-	<?php if($row[4] == 'i2c-b1') : ?>
+	<?php if($row[3] == 'i2c-b1') : ?>
 	<div class="col-md-12 col-sm-12 col-xs-12">
 	<table style="border: none; text-align: left;">
 		<tr>
@@ -212,7 +212,7 @@ function copyToClipboard(text) {
 		</tr>
 		<tr>
 			<td>Story: </td>
-			<td><?php echo $row[3]; ?></td>
+			<td><?php echo $row[2]; ?></td>
 		</tr>
 		<tr>
 			<td>IFSC: </td>


### PR DESCRIPTION
Updated spreadsheet to fix issues with validations page.

Earlier we were reusing Member of which Union column of spreadsheet to record stories from I2C, but that caused issues with validation page because now suddenly all stories became individual unions. 

Instead, we now set i2c-b1 value as union name, map beneficiary id from I2C under union membership number, and use age column to map stories. Current site in prod is fixed to reflect the new changes.