### PR TITLE
Refactor

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -4,3 +4,5 @@ handlers:
   - url: /(.+\.(gif|png|jpg|css|js))$
     static_files: \1
     upload: .+\.(gif|png|jpg|css|js)$
+
+entrypoint: serve front-controller.php

--- a/front-controller.php
+++ b/front-controller.php
@@ -1,0 +1,24 @@
+
+<?php
+switch (@parse_url($_SERVER['REQUEST_URI'])['path']) {
+	case '/update.php':
+		require 'update.php';
+		break;
+	case '/report-bad-upi.php':
+		require 'report-bad-upi.php';
+		break;
+	case '/validation':
+	case '/validation/':
+		require 'validation/index.php';
+		break;
+	case '/validation/update.php':
+		require 'validation/update.php';
+		break;
+	case '/':
+		require 'index.php';
+		break;
+	default:
+		http_response_code(404);
+		exit('Not Found');
+}
+?>

--- a/functions.php
+++ b/functions.php
@@ -57,11 +57,10 @@ function update_lastShown($last_shown){
 	try{
 	$response = $service->spreadsheets_values->update($spreadsheetID, $range, $body, $params);
 	} catch(Exception $e){}
-
 	
 }
 
-function update_displayCount($mobile){
+function recordPageVisit($timestamp, $pageVisitId, $uuid, $userAgent, $mobile) {
 	$client = new Google_Client();
 	$client->setApplicationName($GLOBALS['google_app_name']);
 	$client->setScopes([\Google_Service_Sheets::SPREADSHEETS]);
@@ -73,46 +72,10 @@ function update_displayCount($mobile){
 
 	$spreadsheetID = $GLOBALS['google_spreadsheet_ID'];
 
-	$range = 'Unique Values!A:J';
+	$range = 'Page Visits';
 
-	$response = $service->spreadsheets_values->get($spreadsheetID, $range);
-
-	$values = $response->getValues();
-
-	if($values == NULL){
-		echo 'Invalid Spreadsheet.';
-		exit();
-	}
-
-	$i = 0;
-
-	while(1){
-		$row = $values[$i];
-		if($row[0] == $mobile){
-			//Match Found. Update This Row.
-			break;
-		}
-		else{
-			$i++;
-		}
-	}
-
-	$count = $values[$i][8];
-	if($count == NULL) {
-		$count = 0;
-	}
-
-	$count++;
-	$i = $i+1;
-
-	// UPDATION HAPPENS HERE
-	$service = new Google_Service_Sheets($client);
-
-
-	$range = 'Unique Values!I'.$i;
-	
 	$values = [
-		[$count],
+		["=$timestamp/86400 + DATE(1970,1,1)", $pageVisitId, $uuid, $userAgent, $mobile],
 	];
 
 	$body = new Google_Service_Sheets_ValueRange([
@@ -120,14 +83,16 @@ function update_displayCount($mobile){
 	]);
 
 	$params = [
-		'valueInputOption' => 'RAW'
+		'valueInputOption' => 'USER_ENTERED'
+	];
+
+	$insert = [
+		"insertData" => "INSERT_ROWS"
 	];
 
 	try{
-	$response = $service->spreadsheets_values->update($spreadsheetID, $range, $body, $params);
-	} catch(Exception $e){}
-
-	
+		$response = $service->spreadsheets_values->append($spreadsheetID, $range, $body, $params, $insert);
+	}catch(Exception $e){}
 }
 
 function get_entries(){

--- a/functions.php
+++ b/functions.php
@@ -60,7 +60,7 @@ function update_lastShown($last_shown){
 	
 }
 
-function recordPageVisit($timestamp, $pageVisitId, $uuid, $userAgent, $mobile) {
+function capture($range, $record) {
 	$client = new Google_Client();
 	$client->setApplicationName($GLOBALS['google_app_name']);
 	$client->setScopes([\Google_Service_Sheets::SPREADSHEETS]);
@@ -72,10 +72,8 @@ function recordPageVisit($timestamp, $pageVisitId, $uuid, $userAgent, $mobile) {
 
 	$spreadsheetID = $GLOBALS['google_spreadsheet_ID'];
 
-	$range = 'Page Visits';
-
 	$values = [
-		["=$timestamp/86400 + DATE(1970,1,1)", $pageVisitId, $uuid, $userAgent, $mobile],
+		$record,
 	];
 
 	$body = new Google_Service_Sheets_ValueRange([

--- a/index.php
+++ b/index.php
@@ -1,4 +1,17 @@
 <?php
+
+$timeInSeconds = time();
+$userAgent = $_SERVER['HTTP_USER_AGENT'];
+$uuid = null;
+$uuid_cookie_name = "uuid";
+if(isset($_COOKIE[$uuid_cookie_name])) {
+	$uuid = $_COOKIE[$uuid_cookie_name];
+} else {
+	$uuid = vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex(random_bytes(16)), 4));
+	setcookie($uuid_cookie_name, $uuid, $timeInSeconds + (86400 * 365), "/"); // 86400 = 1 day
+}
+$pageVisitId = bin2hex(random_bytes(16));
+
 // include configurations
 require 'config.php';
 
@@ -71,7 +84,7 @@ $upi = $row[6];
 $form_url = 'report-bad-upi.php?mobile='.$mobile.'&name='.$name.'&upi='.$upi;
 $copy_form_url = 'update.php?mobile='.$mobile;
 
-update_displayCount($mobile);
+recordPageVisit($timeInSeconds, $pageVisitId, $uuid, $userAgent, $mobile);
 
 ?>
 <!doctype html>

--- a/index.php
+++ b/index.php
@@ -67,11 +67,6 @@ if($GLOBALS['seq_entries'] == 1){
 }
 
 $mobile = $row[0];
-$name = $row[1];
-$upi = $row[6];
-$form_url = 'report-bad-upi.php?mobile='.$mobile.'&name='.$name.'&upi='.$upi;
-$copy_form_url = 'update.php?mobile='.$mobile;
-
 
 $timeInSeconds = time();
 $uuid = null;
@@ -84,9 +79,11 @@ if(isset($_COOKIE[$uuid_cookie_name])) {
 	setcookie($uuid_cookie_name, $uuid, $timeInSeconds + (86400 * 365), "/"); // 86400 = 1 day
 	capture('Browser Details', [$uuid, $userAgent]);
 }
+
 $pageVisitId = bin2hex(random_bytes(16));
 capture('Page Visits', ["=$timeInSeconds/86400 + DATE(1970,1,1)", $pageVisitId, $uuid, $mobile]);
-
+$form_url = 'report-bad-upi.php?pageVisitId='.$pageVisitId;
+$copy_form_url = 'update.php?pageVisitId='.$pageVisitId;
 
 ?>
 <!doctype html>

--- a/index.php
+++ b/index.php
@@ -1,17 +1,5 @@
 <?php
 
-$timeInSeconds = time();
-$userAgent = $_SERVER['HTTP_USER_AGENT'];
-$uuid = null;
-$uuid_cookie_name = "uuid";
-if(isset($_COOKIE[$uuid_cookie_name])) {
-	$uuid = $_COOKIE[$uuid_cookie_name];
-} else {
-	$uuid = vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex(random_bytes(16)), 4));
-	setcookie($uuid_cookie_name, $uuid, $timeInSeconds + (86400 * 365), "/"); // 86400 = 1 day
-}
-$pageVisitId = bin2hex(random_bytes(16));
-
 // include configurations
 require 'config.php';
 
@@ -84,7 +72,21 @@ $upi = $row[6];
 $form_url = 'report-bad-upi.php?mobile='.$mobile.'&name='.$name.'&upi='.$upi;
 $copy_form_url = 'update.php?mobile='.$mobile;
 
-recordPageVisit($timeInSeconds, $pageVisitId, $uuid, $userAgent, $mobile);
+
+$timeInSeconds = time();
+$uuid = null;
+$uuid_cookie_name = "uuid";
+if(isset($_COOKIE[$uuid_cookie_name])) {
+	$uuid = $_COOKIE[$uuid_cookie_name];
+} else {
+	$userAgent = $_SERVER['HTTP_USER_AGENT'];
+	$uuid = vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex(random_bytes(16)), 4));
+	setcookie($uuid_cookie_name, $uuid, $timeInSeconds + (86400 * 365), "/"); // 86400 = 1 day
+	capture('Browser Details', [$uuid, $userAgent]);
+}
+$pageVisitId = bin2hex(random_bytes(16));
+capture('Page Visits', ["=$timeInSeconds/86400 + DATE(1970,1,1)", $pageVisitId, $uuid, $mobile]);
+
 
 ?>
 <!doctype html>

--- a/report-bad-upi.php
+++ b/report-bad-upi.php
@@ -4,41 +4,9 @@ require 'config.php';
 
 // include dependencies
 require_once 'libraries/google-api-php-client-2.4.0/vendor/autoload.php';
+require_once 'functions.php';
 
-$mobile = $_GET['mobile'];
-$name = $_GET['name'];
-$upi = $_GET['upi'];
-
-$client = new Google_Client();
-$client->setApplicationName($GLOBALS['google_app_name']);
-$client->setScopes([\Google_Service_Sheets::SPREADSHEETS]);
-$client->setAccessType('offline');
-$client->setAuthConfig(__DIR__.'/assets/'.$GLOBALS['google_sheets_json_filename']);
-$client->setDeveloperKey($GLOBALS['google_sheets_api_auth_key']);
-
-$service = new Google_Service_Sheets($client);
-
-$spreadsheetID = $GLOBALS['google_spreadsheet_ID'];
-
-$range = 'Reported UPIs';
-
-$values = [
-	[$mobile, $name, $upi],
-];
-
-$body = new Google_Service_Sheets_ValueRange([
-	'values' => $values
-]);
-
-$params = [
-	'valueInputOption' => 'RAW'
-];
-
-$insert = [
-	"insertData" => "INSERT_ROWS"
-];
-
-try{
-	$response = $service->spreadsheets_values->append($spreadsheetID, $range, $body, $params, $insert);
-}catch(Exception $e){}
+$pageVisitId = $_GET['pageVisitId'];
+$timeInSeconds = time();
+capture('Failure Reports', ["=$timeInSeconds/86400 + DATE(1970,1,1)", $pageVisitId]);
 ?>

--- a/update.php
+++ b/update.php
@@ -4,71 +4,9 @@ require 'config.php';
 
 // include dependencies
 require_once 'libraries/google-api-php-client-2.4.0/vendor/autoload.php';
+require_once 'functions.php';
 
-$client = new Google_Client();
-$client->setApplicationName($GLOBALS['google_app_name']);
-$client->setScopes([\Google_Service_Sheets::SPREADSHEETS]);
-$client->setAccessType('offline');
-$client->setAuthConfig(__DIR__.'/assets/'.$GLOBALS['google_sheets_json_filename']);
-$client->setDeveloperKey($GLOBALS['google_sheets_api_auth_key']);
-
-$service = new Google_Service_Sheets($client);
-
-$spreadsheetID = $GLOBALS['google_spreadsheet_ID'];
-
-$range = 'Unique Values!A:J';
-
-$response = $service->spreadsheets_values->get($spreadsheetID, $range);
-
-$values = $response->getValues();
-
-if($values == NULL){
-	echo 'Invalid Spreadsheet.';
-	exit();
-}
-
-$mobile = $_GET['mobile'];
-
-$i = 0;
-
-while(1){
-	$row = $values[$i];
-	if($row[0] == $mobile){
-		//Match Found. Update This Row.
-		break;
-	}
-	else{
-		$i++;
-	}
-}
-
-$count = $values[$i][9];
-if($count == NULL) {
-	$count = 0;
-}
-
-$count++;
-$i = $i+1;
-
-
-// UPDATION HAPPENS HERE
-$service = new Google_Service_Sheets($client);
-
-
-$range = 'Unique Values!J'.$i;
-
-$values = [
-	[$count],
-];
-
-$body = new Google_Service_Sheets_ValueRange([
-	'values' => $values
-]);
-
-$params = [
-	'valueInputOption' => 'RAW'
-];
-
-$response = $service->spreadsheets_values->update($spreadsheetID, $range, $body, $params);
-
+$pageVisitId = $_GET['pageVisitId'];
+$timeInSeconds = time();
+capture('Donation Attempts', ["=$timeInSeconds/86400 + DATE(1970,1,1)", $pageVisitId]);
 ?>

--- a/validation/index.php
+++ b/validation/index.php
@@ -1,9 +1,9 @@
 <?php
 // include configurations
-require '../config.php';
+require __DIR__.'/../config.php';
 
 // include dependencies
-require_once '../libraries/google-api-php-client-2.4.0/vendor/autoload.php';
+require_once __DIR__.'/../libraries/google-api-php-client-2.4.0/vendor/autoload.php';
 
 if(!isset($_COOKIE['SkipValue'])){
 	setcookie('SkipValue',0);

--- a/validation/update.php
+++ b/validation/update.php
@@ -1,9 +1,9 @@
 <?php
 // include configurations
-require '../config.php';
+require __DIR__.'/../config.php';
 
 // include dependencies
-require_once '../libraries/google-api-php-client-2.4.0/vendor/autoload.php';
+require_once __DIR__.'/../libraries/google-api-php-client-2.4.0/vendor/autoload.php';
 
 $client = new Google_Client();
 $client->setApplicationName($GLOBALS['google_app_name']);


### PR DESCRIPTION
Includes multiple changes to existing functionality:
1. Tracking devices by cookies to increase observability around repeat visitors.
2. Track events as they happen, associated with unique page hit ID.
3. Removed the need of passing mobile number to client browser, uses page vitit ID instead.
4. Simplified reporting bad details and updating copy counts, doesn't loop through all records anymore.
5. Added front controller as required by gcloud.